### PR TITLE
Use alternative rendering layers (refs #552)

### DIFF
--- a/app/assets/javascripts/pages/welcome.coffee
+++ b/app/assets/javascripts/pages/welcome.coffee
@@ -7,10 +7,13 @@ $ ->
   initMap = ->
     map = L.map('german_map', {closePopupOnClick: false})
 
-    # add an OpenStreetMap tile layer
-    L.tileLayer('//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: '&copy; <a href="//www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-    }).addTo(map)
+    L.tileLayer('//stamen-tiles-{s}.a.ssl.fastly.net/toner-background/{z}/{x}/{y}.png', {
+     	attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+     	subdomains: 'abcd',
+     	minZoom: 0,
+     	maxZoom: 20,
+     	ext: 'png'
+     }).addTo(map);
 
     koeln = new L.Popup()
     koeln.setLatLng([50.938056,6.956944])

--- a/app/assets/stylesheets/pages/single_events.css.scss
+++ b/app/assets/stylesheets/pages/single_events.css.scss
@@ -103,6 +103,7 @@
           #mapCanvas {
             width: 100%;
             height: 100%;
+            border: 2px solid #eaeaea;
           }
         }
       }

--- a/app/assets/stylesheets/pages/welcome.css.sass
+++ b/app/assets/stylesheets/pages/welcome.css.sass
@@ -20,13 +20,13 @@
         border: none
         -webkit-border-radius: 0px
         border-radius: 0px
-        background-color: black
+        background-color: $primary-color
         font-size: 30px
         font-weight: bold
         .leaflet-popup-content
           margin: 0px 10px
           a
-            color: white
+            color: $secondary-color
             &:hover
               text-decoration: none
       .leaflet-popup-tip-container

--- a/app/views/events/_map.html.haml
+++ b/app/views/events/_map.html.haml
@@ -4,10 +4,11 @@
       function initialize() {
         var eventLocation = new L.LatLng(#{event.venue.latitude}, #{event.venue.longitude});
 
-        var map = new L.Map('mapCanvas', { center: eventLocation, zoom: 13, scrollWheelZoom: false });
+        var map = new L.Map('mapCanvas', { center: eventLocation, zoom: 15, scrollWheelZoom: false });
 
-        L.tileLayer('//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-          attribution: '&copy; <a href="//www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        L.tileLayer('//{s}.tile.thunderforest.com/transport/{z}/{x}/{y}.png', {
+        	attribution: '&copy; <a href="http://www.opencyclemap.org">OpenCycleMap</a>, &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+        	maxZoom: 19
         }).addTo(map);
 
         var markerLocation = eventLocation;


### PR DESCRIPTION
Try to improve visibility, look fancy and reduce visual clutter in the
maps on homepage + event pages.
- Use stamen tile for homepage and thunderforest for events
- Add a border to event map
- Increase initial zoom on event map
