### PR TITLE
Adjust Email Settings (fixes #645)

### DIFF
--- a/app/mailers/change_mailer.rb
+++ b/app/mailers/change_mailer.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 class ChangeMailer < ActionMailer::Base
-  default from: "admin@hacken.in"
-
   RECIPIENTS = ["admin@hacken.in"]
 
   def mail_changes(record, old_content)

--- a/app/mailers/new_suggestion_mailer.rb
+++ b/app/mailers/new_suggestion_mailer.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
 class NewSuggestionMailer < ActionMailer::Base
-  default from: "admin@hacken.in"
-
   RECIPIENTS = ["admin@hacken.in"]
   SUBJECT = "[hacken.in Vorschlag] Neuer Vorschlag eingereicht!"
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,14 +42,14 @@ Hcking::Application.configure do
   # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
   # config.assets.precompile += %w( search.js )
 
-  # Disable delivery errors, bad email addresses will be ignored
-  # config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.delivery_method = :sendmail
-  config.action_mailer.sendmail_settings = {
-        location:  '/usr/sbin/sendmail',
-        arguments: '-i -t'
+  # Email Settings
+  config.action_mailer.smtp_settings = {
+    user_name: ENV["MAIL_USERNAME"],
+    password: ENV["MAIL_PASSWORD"],
   }
-  config.action_mailer.default_url_options = { host: "hacken.in" }
+  config.action_mailer.default_options = {
+    from: "notifications@hacken.in"
+  }
 
   # Enable threaded mode
   # config.threadsafe!

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,6 +46,8 @@ Hcking::Application.configure do
   config.action_mailer.smtp_settings = {
     user_name: ENV["MAIL_USERNAME"],
     password: ENV["MAIL_PASSWORD"],
+    port: 587,
+    authentication: :plain
   }
   config.action_mailer.default_options = {
     from: "notifications@hacken.in"


### PR DESCRIPTION
Adjust the settings for the mailer so we can send Mails again 😄
- I created a new Mail account on Uberspace: notifications@hacken.in
- I added `MAIL_USERNAME` and `MAIL_PASSWORD` to `hacken-in-master.secrets`.
- I configured production to use the username and password from the environment.
- I removed `config.action_mailer.delivery_method = :sendmail` so that it defaults to `:smtp`
- I set `port` to 587 as documented [here](https://wiki.uberspace.de/mail)
- I set `authentication` to `:plain`, because that sounded reasonable
- I did not configure the `address` (defaults to "localhost")
- I configured the default `from` to notifications@hacken.in
