### PR TITLE
Re-add limits to db migrations to make rails shut up about schema.rb

### DIFF
--- a/db/migrate/20130504154543_reboot.rb
+++ b/db/migrate/20130504154543_reboot.rb
@@ -1,8 +1,8 @@
 class Reboot < ActiveRecord::Migration
   def change
     create_table "active_admin_comments", :force => true do |t|
-      t.string   "resource_id",   :null => false
-      t.string   "resource_type", :null => false
+      t.string   "resource_id",   null: false
+      t.string   "resource_type", null: false
       t.integer  "author_id"
       t.string   "author_type"
       t.text     "body"
@@ -16,15 +16,15 @@ class Reboot < ActiveRecord::Migration
     add_index "active_admin_comments", ["resource_type", "resource_id"], :name => "index_admin_notes_on_resource_type_and_resource_id"
 
     create_table "authorizations", :force => true do |t|
-      t.string   "provider"
-      t.string   "uid"
+      t.string   "provider",      limit: 255
+      t.string   "uid",           limit: 255
       t.integer  "user_id"
       t.datetime "created_at",    :null => false
       t.datetime "updated_at",    :null => false
-      t.string   "token"
-      t.string   "secret"
+      t.string   "token",         limit: 255
+      t.string   "secret",        limit: 255
       t.datetime "token_expires"
-      t.string   "temp_token"
+      t.string   "temp_token",    limit: 255
     end
 
     add_index "authorizations", ["user_id"], :name => "index_authorizations_on_user_id"
@@ -41,7 +41,7 @@ class Reboot < ActiveRecord::Migration
 
     create_table "calendar_presets", :force => true do |t|
       t.integer  "user_id"
-      t.string   "title"
+      t.string   "title", limit: 255
       t.datetime "created_at", :null => false
       t.datetime "updated_at", :null => false
     end
@@ -49,21 +49,21 @@ class Reboot < ActiveRecord::Migration
     add_index "calendar_presets", ["user_id"], :name => "index_calendar_presets_on_user_id"
 
     create_table "categories", :force => true do |t|
-      t.string   "title"
-      t.string   "color"
+      t.string   "title",              limit: 255
+      t.string   "color",              limit: 255
       t.datetime "created_at",                           :null => false
       t.datetime "updated_at",                           :null => false
       t.boolean  "podcast_category",  :default => false
       t.boolean  "blog_category",     :default => true
       t.boolean  "calendar_category", :default => true
-      t.string   "itunes_url"
+      t.string   "itunes_url",        limit: 255
     end
 
     create_table "comments", :force => true do |t|
       t.text     "body"
       t.integer  "user_id"
       t.integer  "commentable_id"
-      t.string   "commentable_type"
+      t.string   "commentable_type", limit: 255
       t.datetime "created_at"
       t.datetime "updated_at"
     end
@@ -72,18 +72,18 @@ class Reboot < ActiveRecord::Migration
     add_index "comments", ["user_id"], :name => "index_comments_on_user_id"
 
     create_table "events", :force => true do |t|
-      t.string   "name"
+      t.string   "name", limit: 255
       t.text     "description"
       t.text     "schedule_yaml"
-      t.string   "url"
-      t.string   "twitter"
+      t.string   "url", limit: 255
+      t.string   "twitter", limit: 255
       t.datetime "created_at"
       t.datetime "updated_at"
       t.boolean  "full_day",        :default => false
-      t.string   "twitter_hashtag"
+      t.string   "twitter_hashtag", limit: 255
       t.integer  "category_id"
       t.integer  "venue_id"
-      t.string   "venue_info"
+      t.string   "venue_info", limit: 255
       t.integer  "picture_id"
     end
 
@@ -92,32 +92,32 @@ class Reboot < ActiveRecord::Migration
     add_index "events", ["venue_id"], :name => "index_events_on_venue_id"
 
     create_table "pictures", :force => true do |t|
-      t.string   "title"
+      t.string   "title", limit: 255
       t.text     "description"
-      t.string   "box_image"
+      t.string   "box_image", limit: 255
       t.datetime "created_at",          :null => false
       t.datetime "updated_at",          :null => false
-      t.string   "carousel_image"
-      t.string   "advertisement_image"
+      t.string   "carousel_image", limit: 255
+      t.string   "advertisement_image", limit: 255
     end
 
     create_table "single_events", :force => true do |t|
-      t.string   "name"
+      t.string   "name", limit: 255
       t.text     "description"
       t.integer  "event_id"
       t.datetime "created_at"
       t.datetime "updated_at"
       t.datetime "occurrence"
-      t.string   "url"
+      t.string   "url", limit: 255
       t.integer  "duration"
       t.boolean  "full_day"
-      t.string   "twitter_hashtag"
+      t.string   "twitter_hashtag", limit: 255
       t.boolean  "based_on_rule",           :default => false
       t.integer  "category_id"
       t.integer  "venue_id"
-      t.string   "venue_info"
+      t.string   "venue_info", limit: 255
       t.integer  "picture_id"
-      t.string   "twitter"
+      t.string   "twitter", limit: 255
       t.boolean  "use_venue_info_of_event", :default => true
     end
 
@@ -135,8 +135,8 @@ class Reboot < ActiveRecord::Migration
     add_index "single_events_users", ["user_id"], :name => "index_single_events_users_on_user_id"
 
     create_table "suggestions", :force => true do |t|
-      t.string   "name"
-      t.string   "occurrence"
+      t.string   "name", limit: 255
+      t.string   "occurrence", limit: 255
       t.text     "description"
       t.text     "place"
       t.text     "more"
@@ -147,10 +147,10 @@ class Reboot < ActiveRecord::Migration
     create_table "taggings", :force => true do |t|
       t.integer  "tag_id"
       t.integer  "taggable_id"
-      t.string   "taggable_type"
+      t.string   "taggable_type", limit: 255
       t.integer  "tagger_id"
-      t.string   "tagger_type"
-      t.string   "context"
+      t.string   "tagger_type", limit: 255
+      t.string   "context", limit: 255
       t.datetime "created_at"
     end
 
@@ -159,16 +159,16 @@ class Reboot < ActiveRecord::Migration
     add_index "taggings", ["tagger_id", "tagger_type"], :name => "index_taggings_on_tagger_id_and_tagger_type"
 
     create_table "tags", :force => true do |t|
-      t.string  "name"
+      t.string  "name", limit: 255
       t.integer "category_id"
     end
 
     add_index "tags", ["category_id"], :name => "index_tags_on_category_id"
 
     create_table "thisiscologne_pictures", :force => true do |t|
-      t.string   "description"
-      t.string   "image_url"
-      t.string   "link"
+      t.string   "description", limit: 255
+      t.string   "image_url", limit: 255
+      t.string   "link", limit: 255
       t.datetime "time"
       t.datetime "created_at",  :null => false
       t.datetime "updated_at",  :null => false
@@ -177,29 +177,29 @@ class Reboot < ActiveRecord::Migration
     add_index "thisiscologne_pictures", ["image_url"], :name => "index_thisiscologne_pictures_on_image_url", :unique => true
 
     create_table "users", :force => true do |t|
-      t.string   "email"
-      t.string   "encrypted_password"
-      t.string   "reset_password_token"
+      t.string   "email", limit: 255
+      t.string   "encrypted_password", limit: 255
+      t.string   "reset_password_token", limit: 255
       t.datetime "remember_created_at"
       t.integer  "sign_in_count",          :default => 0
       t.datetime "current_sign_in_at"
       t.datetime "last_sign_in_at"
-      t.string   "current_sign_in_ip"
-      t.string   "last_sign_in_ip"
+      t.string   "current_sign_in_ip", limit: 255
+      t.string   "last_sign_in_ip", limit: 255
       t.datetime "created_at"
       t.datetime "updated_at"
       t.boolean  "admin",                  :default => false
-      t.string   "nickname",               :default => "",    :null => false
+      t.string   "nickname",               default: "", null: false, limit: 255
       t.text     "description"
-      t.string   "github"
-      t.string   "twitter"
-      t.string   "homepage"
-      t.string   "guid"
+      t.string   "github", limit: 255
+      t.string   "twitter", limit: 255
+      t.string   "homepage", limit: 255
+      t.string   "guid", limit: 255
       t.boolean  "allow_ignore_view"
       t.datetime "reset_password_sent_at"
-      t.string   "image_url"
-      t.string   "team"
-      t.string   "name"
+      t.string   "image_url", limit: 255
+      t.string   "team", limit: 255
+      t.string   "name", limit: 255
     end
 
     add_index "users", ["email"], :name => "index_users_on_email", :unique => true
@@ -207,16 +207,16 @@ class Reboot < ActiveRecord::Migration
     add_index "users", ["reset_password_token"], :name => "index_users_on_reset_password_token", :unique => true
 
     create_table "venues", :force => true do |t|
-      t.string   "location"
-      t.string   "street"
-      t.string   "zipcode"
-      t.string   "city"
-      t.string   "country"
+      t.string   "location", limit: 255
+      t.string   "street", limit: 255
+      t.string   "zipcode", limit: 255
+      t.string   "city", limit: 255
+      t.string   "country", limit: 255
       t.float    "latitude"
       t.float    "longitude"
       t.datetime "created_at", :null => false
       t.datetime "updated_at", :null => false
-      t.string   "url"
+      t.string   "url", limit: 255
     end
 
     add_index "venues", ["latitude", "longitude"], :name => "index_venues_on_latitude_and_longitude"

--- a/db/migrate/20130509113337_create_regions.rb
+++ b/db/migrate/20130509113337_create_regions.rb
@@ -1,8 +1,8 @@
 class CreateRegions < ActiveRecord::Migration
   def change
     create_table :regions do |t|
-      t.string :name
-      t.string :slug
+      t.string :name, limit: 255
+      t.string :slug, limit: 255
       t.float :latitude
       t.float :longitude
       t.float :perimeter, default: 20

--- a/db/migrate/20130524191654_add_gravatar_email_to_user.rb
+++ b/db/migrate/20130524191654_add_gravatar_email_to_user.rb
@@ -1,5 +1,5 @@
 class AddGravatarEmailToUser < ActiveRecord::Migration
   def change
-    add_column :users, :gravatar_email, :string
+    add_column :users, :gravatar_email, :string, limit: 255
   end
 end

--- a/db/migrate/20130530132853_remove_active_admin_comments.rb
+++ b/db/migrate/20130530132853_remove_active_admin_comments.rb
@@ -5,14 +5,14 @@ class RemoveActiveAdminComments < ActiveRecord::Migration
 
   def down
     create_table "active_admin_comments" do |t|
-      t.string   "resource_id"
-      t.string   "resource_type"
+      t.string   "resource_id", limit: 255
+      t.string   "resource_type", limit: 255
       t.integer  "author_id"
-      t.string   "author_type"
+      t.string   "author_type", limit: 255
       t.text     "body"
       t.datetime "created_at"
       t.datetime "updated_at"
-      t.string   "namespace"
+      t.string   "namespace", limit: 255
     end
 
     add_index "active_admin_comments"

--- a/db/migrate/20130715192011_create_single_event_external_users.rb
+++ b/db/migrate/20130715192011_create_single_event_external_users.rb
@@ -2,8 +2,8 @@ class CreateSingleEventExternalUsers < ActiveRecord::Migration
   def change
     create_table :single_event_external_users do |t|
       t.references :single_event
-      t.string :email
-      t.string :name
+      t.string :email, limit: 255
+      t.string :name, limit: 255
 
       t.timestamps
     end

--- a/db/migrate/20130715194507_add_session_token_to_single_event_external_users.rb
+++ b/db/migrate/20130715194507_add_session_token_to_single_event_external_users.rb
@@ -1,5 +1,5 @@
 class AddSessionTokenToSingleEventExternalUsers < ActiveRecord::Migration
   def change
-    add_column :single_event_external_users, :session_token, :string, after: :email
+    add_column :single_event_external_users, :session_token, :string, after: :email, limit: 255
   end
 end

--- a/db/migrate/20130728123334_add_email_address_to_suggestion.rb
+++ b/db/migrate/20130728123334_add_email_address_to_suggestion.rb
@@ -1,5 +1,5 @@
 class AddEmailAddressToSuggestion < ActiveRecord::Migration
   def change
-    add_column :suggestions, :email_address, :string
+    add_column :suggestions, :email_address, :string, limit: 255
   end
 end

--- a/db/migrate/20140301102217_create_radar_settings.rb
+++ b/db/migrate/20140301102217_create_radar_settings.rb
@@ -2,10 +2,10 @@ class CreateRadarSettings < ActiveRecord::Migration
   def change
     create_table :radar_settings do |t|
       t.integer :event_id
-      t.string :url
-      t.string :radar_type
+      t.string :url, limit: 255
+      t.string :radar_type, limit: 255
       t.datetime :last_processed
-      t.string :last_result
+      t.string :last_result, limit: 255
     end
   end
 end

--- a/db/migrate/20140301102753_create_radar_entry.rb
+++ b/db/migrate/20140301102753_create_radar_entry.rb
@@ -2,9 +2,9 @@ class CreateRadarEntry < ActiveRecord::Migration
   def change
     create_table :radar_entries do |t|
       t.integer :radar_setting_id
-      t.integer :entry_id
+      t.string :entry_id, limit: 255
       t.datetime :entry_date
-      t.string :state
+      t.string :state, limit: 255
       t.text :content
       t.text :previous_confirmed_content
     end

--- a/db/migrate/20140301141104_change_entry_id_in_radar_entry.rb
+++ b/db/migrate/20140301141104_change_entry_id_in_radar_entry.rb
@@ -1,5 +1,5 @@
 class ChangeEntryIdInRadarEntry < ActiveRecord::Migration
   def change
-    change_column :radar_entries, :entry_id, :string
+    change_column :radar_entries, :entry_id, :string, limit: 255
   end
 end

--- a/db/migrate/20140301193843_add_entry_type_to_radar_entries.rb
+++ b/db/migrate/20140301193843_add_entry_type_to_radar_entries.rb
@@ -1,5 +1,5 @@
 class AddEntryTypeToRadarEntries < ActiveRecord::Migration
   def change
-    add_column :radar_entries, :entry_type, :string
+    add_column :radar_entries, :entry_type, :string, limit: 255
   end
 end

--- a/db/migrate/20141227182236_create_visits.rb
+++ b/db/migrate/20141227182236_create_visits.rb
@@ -5,7 +5,7 @@ class CreateVisits < ActiveRecord::Migration
       t.uuid :visitor_id
 
       # standard
-      t.string :ip
+      t.string :ip, limit: 255
       t.text :user_agent
       t.text :referrer
       t.text :landing_page
@@ -14,30 +14,30 @@ class CreateVisits < ActiveRecord::Migration
       t.integer :user_id
 
       # traffic source
-      t.string :referring_domain
-      t.string :search_keyword
+      t.string :referring_domain, limit: 255
+      t.string :search_keyword, limit: 255
 
       # technology
-      t.string :browser
-      t.string :os
-      t.string :device_type
+      t.string :browser, limit: 255
+      t.string :os, limit: 255
+      t.string :device_type, limit: 255
 
       # location
-      t.string :country
-      t.string :region
-      t.string :city
+      t.string :country, limit: 255
+      t.string :region, limit: 255
+      t.string :city, limit: 255
 
       # utm parameters
-      t.string :utm_source
-      t.string :utm_medium
-      t.string :utm_term
-      t.string :utm_content
-      t.string :utm_campaign
+      t.string :utm_source, limit: 255
+      t.string :utm_medium, limit: 255
+      t.string :utm_term, limit: 255
+      t.string :utm_content, limit: 255
+      t.string :utm_campaign, limit: 255
 
       # native apps
-      t.string :platform
-      t.string :app_version
-      t.string :os_version
+      t.string :platform, limit: 255
+      t.string :app_version, limit: 255
+      t.string :os_version, limit: 255
 
       t.timestamp :started_at
     end

--- a/db/migrate/20141227182301_create_ahoy_events.rb
+++ b/db/migrate/20141227182301_create_ahoy_events.rb
@@ -7,7 +7,7 @@ class CreateAhoyEvents < ActiveRecord::Migration
       # user
       t.integer :user_id
 
-      t.string :name
+      t.string :name, limit: 255
       t.json :properties
       t.timestamp :time
     end


### PR DESCRIPTION
Re-add length limits to all strings field without a specified length (and fix one case of type confusion where `event_id` on the radar table was specified as an integer.

This just reflects the current state of the database

![screenshot_20170226_130048](https://cloud.githubusercontent.com/assets/51264/23339627/0991e01e-fc27-11e6-9f55-48c79e9b07bf.png)

and should mute one of those three remaining modified files:

![screenshot_20170226_132612](https://cloud.githubusercontent.com/assets/51264/23339638/3b3033f0-fc27-11e6-8ad0-6c9b237aed67.png)
