### PR TITLE
Install latest bundler at box build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY Gemfile* /app/
 RUN apt-get update -qq && \
   mkdir -p /app/tmp /gems && \
   apt-get install -y build-essential libpq-dev && \
+  gem install bundler \ # upgrade to latest Bundler
   groupadd --gid 4711 hacken && \
   useradd -m --uid 4711 --gid 4711 hacken && \
   chown hacken:hacken -Rv /app /gems


### PR DESCRIPTION
This should give us a more recent bundler version and at the same time
fix #666.